### PR TITLE
Trap exception when failed to move blob to tombstone.

### DIFF
--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -34,6 +34,8 @@ module FileStore
               source_blob_name)
       # delete the file
       blob_service.delete_blob(azure_blob_container, source_blob_name)
+    rescue StandardError => exception
+      Rails.logger.warn("Blob can not be moved to tombstone: #{exception}\nUrl: #{url}\nBlob: #{source_blob_name}")
     end
 
     def has_been_uploaded?(url)


### PR DESCRIPTION
When a blob needs to be removed (i.e. moved to tombstone) but it doesn't exist (for whatever reason), do not fail.  Instead, trap the exception and allow the process through.  Log with a warning instead.