### PR TITLE
FIX: Implement url_for

### DIFF
--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -79,7 +79,7 @@ module FileStore
       url.sub("#{schema}#{absolute_base_url}", SiteSetting.azure_cdn_url)
     end
 
-    def url_for(upload)
+    def url_for(upload, force_download: false)
       upload.url
     end
 

--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -79,6 +79,17 @@ module FileStore
       url.sub("#{schema}#{absolute_base_url}", SiteSetting.azure_cdn_url)
     end
 
+    def url_for(upload, force_download: false)
+      if force_download
+        uri = URI.parse(upload.url)
+        uri.query = [uri.query, "rscd=file;%20attachment"].compact.join('&')
+        url = uri.to_s
+      else
+        url = upload.url
+      end
+      url
+    end
+
     def external?
       true
     end

--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -83,11 +83,9 @@ module FileStore
       if force_download
         uri = URI.parse(upload.url)
         uri.query = [uri.query, "rscd=file;%20attachment"].compact.join('&')
-        url = uri.to_s
-      else
-        url = upload.url
+        return uri.to_s
       end
-      url
+      upload.url
     end
 
     def external?

--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -79,12 +79,7 @@ module FileStore
       url.sub("#{schema}#{absolute_base_url}", SiteSetting.azure_cdn_url)
     end
 
-    def url_for(upload, force_download: false)
-      if force_download
-        uri = URI.parse(upload.url)
-        uri.query = [uri.query, "rscd=file;%20attachment"].compact.join('&')
-        return uri.to_s
-      end
+    def url_for(upload)
       upload.url
     end
 

--- a/spec/lib/azure_blob_store_spec.rb
+++ b/spec/lib/azure_blob_store_spec.rb
@@ -157,11 +157,5 @@ describe FileStore::AzureStore do
       url = store.url_for(upload)
       expect(url).to eq(test)
     end 
-    it "adds rscd param to url" do
-      test = "//example.com/path/file.ext"
-      upload = Upload.new(url: test)
-      url = store.url_for(upload, force_download: true)
-      expect(url).to eq(test + '?rscd=file;%20attachment')
-    end 
   end
 end

--- a/spec/lib/azure_blob_store_spec.rb
+++ b/spec/lib/azure_blob_store_spec.rb
@@ -151,15 +151,6 @@ describe FileStore::AzureStore do
   end
 
   describe ".url_for" do
-    def assert_url(url, expected)
-      upload = Upload.new(url: url)
-
-      url = store.url_for(upload)
-      expected = FileStore::LocalStore.new.url_for(upload) if expected
-
-      expect(url).to eq(expected)
-    end
-
     it "returns url from upload" do
       test = "//example.com/path/file.ext"
       upload = Upload.new(url: test)

--- a/spec/lib/azure_blob_store_spec.rb
+++ b/spec/lib/azure_blob_store_spec.rb
@@ -149,4 +149,28 @@ describe FileStore::AzureStore do
       assert_path("https://hello", nil)
     end
   end
+
+  describe ".url_for" do
+    def assert_url(url, expected)
+      upload = Upload.new(url: url)
+
+      url = store.url_for(upload)
+      expected = FileStore::LocalStore.new.url_for(upload) if expected
+
+      expect(url).to eq(expected)
+    end
+
+    it "returns url from upload" do
+      test = "//example.com/path/file.ext"
+      upload = Upload.new(url: test)
+      url = store.url_for(upload)
+      expect(url).to eq(test)
+    end 
+    it "adds rscd param to url" do
+      test = "//example.com/path/file.ext"
+      upload = Upload.new(url: test)
+      url = store.url_for(upload, force_download: true)
+      expect(url).to eq(test + '?rscd=file;%20attachment')
+    end 
+  end
 end

--- a/spec/lib/azure_blob_store_spec.rb
+++ b/spec/lib/azure_blob_store_spec.rb
@@ -156,6 +156,12 @@ describe FileStore::AzureStore do
       upload = Upload.new(url: test)
       url = store.url_for(upload)
       expect(url).to eq(test)
+    end
+    it "accepts force_download parameter" do
+      test = "//example.com/path/file.ext"
+      upload = Upload.new(url: test)
+      url = store.url_for(upload, force_download: true)
+      expect(url).to eq(test)
     end 
   end
 end


### PR DESCRIPTION
This PR implements [the `url_for` function](https://github.com/discourse/discourse/pull/7845) which Discourse uses to determine the URL of a download, taking into account the `force_download` parameter to [correctly set the `content-disposition` parameter for Azure](https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas#specifying-query-parameters-to-override-response-headers-blob-service-and-file-service-only).

This fixes [the bug that was preventing users from downloading files stored in Azure](https://meta.discourse.org/t/user-archive-impossible-to-download-error-nomethoderror-filestore-azurestore/123687).