### PR TITLE
DEV: Update gems, and other tweaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :development do
+  gem 'rubocop-discourse'
+end

--- a/lib/azure_blob_store.rb
+++ b/lib/azure_blob_store.rb
@@ -63,7 +63,7 @@ module FileStore
     end
 
     def purge_tombstone(grace_period)
-      blob_list = blob_service.list_blobs(azure_blob_container, {prefix: "tombstone"})
+      blob_list = blob_service.list_blobs(azure_blob_container, { prefix: "tombstone" })
       blob_list.each do |blob|
         last_modified_diff = ((Time.now.utc - Time.parse(blob.properties[:last_modified])) / 1.day).round
         blob_service.delete_blob(azure_blob_container, blob.name) if last_modified_diff > grace_period
@@ -84,12 +84,12 @@ module FileStore
     def url_for(upload, force_download: false)
       upload.url
     end
-    
+
     def download_url(upload)
       return unless upload
       "#{upload.short_path}"
     end
-    
+
     def external?
       true
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,16 +7,23 @@
 require "file_store/base_store"
 
 # GEMS
-gem 'faraday_middleware', '1.0.0', {require: false}
-gem 'net-http-persistent', '4.0.0', {require: false}
-gem 'azure-storage-common', '2.0.2', {require: false}
-gem 'azure-storage-blob', '2.0.1', {require: false}
+gem 'net-http-persistent', '4.0.1', { require: true, require_name: "net/http/persistent" }
+gem 'faraday_middleware', '1.2.0', { require: false }
+gem 'azure-storage-common', '2.0.4', { require: false }
+gem 'azure-storage-blob', '2.0.3', { require: false }
 
 require 'azure/storage/blob'
 
 enabled_site_setting :azure_blob_storage_enabled
 
 after_initialize do
+  class ::Faraday::Adapter::NetHttpPersistent
+    def self.new(*)
+      self.load_error = nil
+
+      super
+    end
+  end
 
   SiteSetting::Upload.class_eval do
     class << self

--- a/spec/lib/azure_blob_store_spec.rb
+++ b/spec/lib/azure_blob_store_spec.rb
@@ -62,7 +62,7 @@ describe FileStore::AzureStore do
         stub_request(:delete, old_url)
         stub_request(:put, new_url)
 
-        new_optimized = upload.get_optimized_image(20, 20, allow_animation: SiteSetting.allow_animated_avatars)
+        new_optimized = upload.get_optimized_image(20, 20)
         expect("https:#{new_optimized.url}").to eq(new_url)
       end
     end
@@ -84,13 +84,6 @@ describe FileStore::AzureStore do
     end
 
     describe "#remove_optimized_image" do
-      let(:optimized_image) do
-        Fabricate(:optimized_image,
-          url: "//azure-blob-account-name.blob.core.windows.net/optimized/1X/#{upload.sha1}_1_100x200.png",
-          upload: upload
-        )
-      end
-
       it "removes the file from Azure storage with the right paths" do
         store.expects(:get_depth_for).with(optimized_image.upload.id).returns(0)
         store.expects(:has_been_uploaded?).returns(true)
@@ -162,6 +155,6 @@ describe FileStore::AzureStore do
       upload = Upload.new(url: test)
       url = store.url_for(upload, force_download: true)
       expect(url).to eq(test)
-    end 
+    end
   end
 end


### PR DESCRIPTION
Some tweaks to allow the plugin to be installed:

- Update gems, including suppressing errors in `NetHttpPersistent`
- Remove reference to `allow_animated_avatars` as this is no longer supported
- Add a `Gemfile` with `rubocop-discourse`